### PR TITLE
[GN-35] chore: 배포 자동화 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: Creates output
+        run: sh ./build.sh
+
+      - name: Set target branch
+        id: set_target
+        run: |
+          if [ ${{ github.ref }} = 'refs/heads/main' ]; then
+            echo "TARGET_BRANCH=main" >> $GITHUB_OUTPUT
+          else
+            echo "TARGET_BRANCH=develop" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: wch2208
+          destination-repository-name: K-venture
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: ${{ steps.set_target.outputs.TARGET_BRANCH }}
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./K-venture/* ./output
+cp -R ./output ./K-venture/


### PR DESCRIPTION
## 연관된 이슈
없음

## 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- [x] 메인과 디벨롭 브랜치에 push를 감지해서 동작합니다. 
- [x] 메인에서 감지되면 배포용 메인으로 디벨롭에서 감지되면 배포용 디벨롭 브랜치에 업데이트합니다.

## 스크린샷
없음

## 코멘트 및 논의 사항
연결 후 오류 메세지 보면서 수정해보려고 합니다