### PR TITLE
[GN-86] chore: 배포 자동화 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy
+on:
+  push:
+    branches:
+      - main
+      - develop
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    container: pandoc/latex
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install mustache (to update the date)
+        run: apk add ruby && gem install mustache
+
+      - name: Creates output
+        run: sh ./build.sh
+
+      - name: Set target branch
+        id: set_target
+        run: |
+          if [ ${{ github.ref }} = 'refs/heads/main' ]; then
+            echo "TARGET_BRANCH=main" >> $GITHUB_OUTPUT
+          else
+            echo "TARGET_BRANCH=develop" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Pushes to another repository
+        id: push_directory
+        uses: cpina/github-action-push-to-another-repository@main
+        env:
+          API_TOKEN_GITHUB: ${{ secrets.AUTO_ACTIONS }}
+        with:
+          source-directory: "output"
+          destination-github-username: wch2208
+          destination-repository-name: K-venture
+          user-email: ${{ secrets.EMAIL }}
+          commit-message: ${{ github.event.commits[0].message }}
+          target-branch: ${{ steps.set_target.outputs.TARGET_BRANCH }}
+
+      - name: Test get variable exported by push-to-another-repository
+        run: echo $DESTINATION_CLONED_DIRECTORY

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,5 @@
+#!/bin/sh
+cd ../
+mkdir output
+cp -R ./K-venture/* ./output
+cp -R ./output ./K-venture/


### PR DESCRIPTION
## 연관된 이슈
없음

## 작업 내용

팀 레포지토리의 업데이트를 개인 레포지토리에 자동으로 동기화하고, 이를 Vercel을 통해 자동 배포하는 CI/CD 파이프라인 구축

- [x] main의 push를 감지해서 배포용 레포의 main 업데이트
- [x] develop의 push를 감지해서 배포용 레포의 develop 업데이트

## 스크린샷
없음

## 코멘트 및 논의 사항
커밋히스토리 정리를 위해 다시 생성합니다.