### PR TITLE
[GN-113] chore: precommit에 타입검사 추가

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,3 +1,3 @@
-#!/usr/bin/env sh. 
+#!/usr/bin/env sh
 
-yarn lint-staged
+yarn tsc --noEmit && yarn lint-staged


### PR DESCRIPTION
## 연관된 이슈
GN-112

## 작업 내용
- [x] precommit에 타입검사를 추가했습니다. 

## 스크린샷
![image](https://github.com/user-attachments/assets/b076aac8-006b-431c-834d-9b7bd6c27156)


## 코멘트 및 논의 사항

커밋 생성 시 타입검사를 실행합니다.
import 경로에 오타를 만들고 커밋을 실행한 결과 오류메세지를 잘 출력하는 것을 확인했습니다.