### PR TITLE
[GN-156] fix: 승인,거절 요청 후 리스트 재랜더링 추가

### DIFF
--- a/src/components/ReservationDashboardPage/DailyReservationModal/DailyReservationList.tsx
+++ b/src/components/ReservationDashboardPage/DailyReservationModal/DailyReservationList.tsx
@@ -13,7 +13,7 @@ export default function DailyReservationList() {
     dailyReservationModalAtom,
   );
   const patchReservationStatus = usePatchReservationStatus();
-  const { reservationList, ref, hasNextPage, isFetchingNextPage } =
+  const { reservationList, ref, hasNextPage, isFetchingNextPage, refetch } =
     useDailyReservationListInfinite();
 
   const handleReservationActionClick = ({
@@ -35,7 +35,11 @@ export default function DailyReservationList() {
       activityId,
     };
 
-    patchReservationStatus.mutate(params);
+    patchReservationStatus.mutate(params, {
+      onSuccess: () => {
+        refetch();
+      },
+    });
   };
 
   return (

--- a/src/hooks/useDailyReservationListInfinite.ts
+++ b/src/hooks/useDailyReservationListInfinite.ts
@@ -18,6 +18,7 @@ const useDailyReservationListInfinite = () => {
     fetchNextPage,
     hasNextPage,
     isFetchingNextPage,
+    refetch,
   } = useInfiniteQuery({
     queryKey: [
       'reservationsList',
@@ -50,6 +51,7 @@ const useDailyReservationListInfinite = () => {
     ref,
     hasNextPage,
     isFetchingNextPage,
+    refetch,
   };
 };
 


### PR DESCRIPTION
## 연관된 이슈
[GN-156]
[GN-132] (예약 내역 무한스크롤) #60 


## 작업 내용
- [x] 예약 내역 리스트에서 신청 탭의 내용에는 승인, 거절하기 버튼 액션이 있습니다. 해당 동작 후 리스트에서 제거되어야하는데 유지되고 있는 현상을 수정했습니다.

## 스크린샷
![승인 거절 액션 후 리스트 재랜더링](https://github.com/user-attachments/assets/f5615f9b-b37f-4bb3-a3d7-e1d5dd581a00)


[GN-156]: https://codeitsprint6team1.atlassian.net/browse/GN-156?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[GN-132]: https://codeitsprint6team1.atlassian.net/browse/GN-132?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ