### PR TITLE
[GN-165] fix: 체험 상세 별점 및 주소 아이콘 위치 수정

### DIFF
--- a/src/components/activity/Location.tsx
+++ b/src/components/activity/Location.tsx
@@ -8,7 +8,7 @@ export default function Location({ address }: LocationProps) {
   return (
     <div className="flex items-center gap-1">
       <LocationIcon />
-      <p>{address}</p>
+      <p className="text-kv-lg mobile:text-kv-md">{address}</p>
     </div>
   );
 }

--- a/src/components/activity/Review.tsx
+++ b/src/components/activity/Review.tsx
@@ -14,8 +14,8 @@ export function ReviewRating({ reviewCount, rating }: ReviewProps) {
   return (
     <div className="flex items-center gap-1">
       <StartIcon />
-      <p>
-        {rating} ({reviewCount.toLocaleString()})
+      <p className="text-kv-lg mobile:text-kv-md">
+        {rating.toFixed(1)} ({reviewCount.toLocaleString()})
       </p>
     </div>
   );

--- a/src/pages/activity/[id].tsx
+++ b/src/pages/activity/[id].tsx
@@ -56,7 +56,7 @@ export default function ActivityPage() {
           <h2 className="mb-4 mt-2 text-kv-3xl font-kv-bold mobile:text-kv-2xl">
             {activityData.title}
           </h2>
-          <div className="flex items-center gap-3">
+          <div className="flex items-center gap-2 sm:gap-3">
             <ReviewRating
               reviewCount={activityData.reviewCount}
               rating={activityData.rating}


### PR DESCRIPTION
## 연관된 이슈

GN-165

## 작업 내용

- [x] 별점 소수점 제거
- [x] 모바일일 때(`max-width:768px`) 별점, 주소 텍스트 크기 작게(`16px -> 14px`) 수정

## 스크린샷
![image](https://github.com/user-attachments/assets/a90aed48-82ad-4c50-a520-50005889f0cc)

