### PR TITLE
[GN-150] fix: 체험등록 인풋, 시간 선택 수정

### DIFF
--- a/src/components/MyActivityEditPage/MyActivityEditForm.tsx
+++ b/src/components/MyActivityEditPage/MyActivityEditForm.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { useEffect, useState } from 'react';
 import { useDaumPostcodePopup } from 'react-daum-postcode';
 import { useForm } from 'react-hook-form';
-import * as yup from 'yup';
 
 import ValueDropdown from '@/components/common/Dropdown/ValueDropdown';
 import ErrorText from '@/components/common/ErrorText';
@@ -15,14 +14,12 @@ import useDropdown from '@/hooks/useDropdown';
 import useImageManager from '@/hooks/useImageManager';
 import { updateActivity } from '@/lib/apis/patchApis';
 import { postActivityImage } from '@/lib/apis/postApis';
+import { activityFormSchema } from '@/lib/utils/activityFormSchema';
 import {
   convertAPItoSelected,
   convertYYMMDDtoYMD,
 } from '@/lib/utils/formatDate';
-import {
-  activityFormSchema,
-  checkDuplication,
-} from '@/lib/utils/myActivityPage';
+import { checkDuplication } from '@/lib/utils/myActivityPage';
 import { CATEGORIES, Schedule } from '@/types/activityTypes';
 import { ActivityDetailResponse } from '@/types/page/myActivityEditPageTypes';
 import { IMAGE_TYPES } from '@/types/page/myActivityPageTypes';

--- a/src/components/MyActivityEditPage/MyActivityEditForm.tsx
+++ b/src/components/MyActivityEditPage/MyActivityEditForm.tsx
@@ -19,7 +19,10 @@ import {
   convertAPItoSelected,
   convertYYMMDDtoYMD,
 } from '@/lib/utils/formatDate';
-import { checkDuplication } from '@/lib/utils/myActivityPage';
+import {
+  activityFormSchema,
+  checkDuplication,
+} from '@/lib/utils/myActivityPage';
 import { CATEGORIES, Schedule } from '@/types/activityTypes';
 import { ActivityDetailResponse } from '@/types/page/myActivityEditPageTypes';
 import { IMAGE_TYPES } from '@/types/page/myActivityPageTypes';
@@ -37,17 +40,6 @@ interface InputForm {
   price: number;
   address: string;
 }
-
-const schema = yup.object().shape({
-  title: yup.string().required('제목을 입력해주세요.'),
-  description: yup.string().required('설명을 입력해주세요.'),
-  price: yup
-    .number()
-    .positive('가격은 양수여야 합니다.')
-    .integer('가격은 정수여야 합니다.')
-    .required('가격을 입력해주세요.'),
-  address: yup.string().required('주소를 입력해주세요.'),
-});
 
 export default function MyActivityEditForm({
   initialData,
@@ -74,7 +66,7 @@ export default function MyActivityEditForm({
     formState: { errors, isValid },
     trigger,
   } = useForm<InputForm>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(activityFormSchema),
     mode: 'onChange',
   });
 

--- a/src/components/MyActivityEditPage/MyActivityEditForm.tsx
+++ b/src/components/MyActivityEditPage/MyActivityEditForm.tsx
@@ -291,7 +291,7 @@ export default function MyActivityEditForm({
         <div className="flex flex-col">
           <h2 className="h2-my-act">가격</h2>
           <input
-            className="input-my-act"
+            className="input-my-act no-spinner"
             id="price"
             type="number"
             placeholder="*가격"

--- a/src/components/MyActivityPage/MyActivityForm.tsx
+++ b/src/components/MyActivityPage/MyActivityForm.tsx
@@ -13,11 +13,9 @@ import { MAX_IMG_LENGTH } from '@/constants/myActivityPage';
 import useDropdown from '@/hooks/useDropdown';
 import useImageManager from '@/hooks/useImageManager';
 import { postActivity, postActivityImage } from '@/lib/apis/postApis';
+import { activityFormSchema } from '@/lib/utils/activityFormSchema';
 import { convertYYMMDDtoYMD } from '@/lib/utils/formatDate';
-import {
-  activityFormSchema,
-  checkDuplication,
-} from '@/lib/utils/myActivityPage';
+import { checkDuplication } from '@/lib/utils/myActivityPage';
 import { CATEGORIES, Schedule } from '@/types/activityTypes';
 import { IMAGE_TYPES } from '@/types/page/myActivityPageTypes';
 

--- a/src/components/MyActivityPage/MyActivityForm.tsx
+++ b/src/components/MyActivityPage/MyActivityForm.tsx
@@ -4,7 +4,6 @@ import { useRouter } from 'next/router';
 import { useState } from 'react';
 import { useDaumPostcodePopup } from 'react-daum-postcode';
 import { useForm } from 'react-hook-form';
-import * as yup from 'yup';
 
 import ValueDropdown from '@/components/common/Dropdown/ValueDropdown';
 import ErrorText from '@/components/common/ErrorText';
@@ -15,7 +14,10 @@ import useDropdown from '@/hooks/useDropdown';
 import useImageManager from '@/hooks/useImageManager';
 import { postActivity, postActivityImage } from '@/lib/apis/postApis';
 import { convertYYMMDDtoYMD } from '@/lib/utils/formatDate';
-import { checkDuplication } from '@/lib/utils/myActivityPage';
+import {
+  activityFormSchema,
+  checkDuplication,
+} from '@/lib/utils/myActivityPage';
 import { CATEGORIES, Schedule } from '@/types/activityTypes';
 import { IMAGE_TYPES } from '@/types/page/myActivityPageTypes';
 
@@ -32,17 +34,6 @@ interface InputForm {
   price: number;
   address: string;
 }
-
-const schema = yup.object().shape({
-  title: yup.string().required('제목을 입력해주세요.'),
-  description: yup.string().required('설명을 입력해주세요.'),
-  price: yup
-    .number()
-    .positive('가격은 양수여야 합니다.')
-    .integer('가격은 정수여야 합니다.')
-    .required('가격을 입력해주세요.'),
-  address: yup.string().required('주소를 입력해주세요.'),
-});
 
 export default function MyActivityForm() {
   const category = useDropdown('');
@@ -61,7 +52,7 @@ export default function MyActivityForm() {
     handleSubmit,
     formState: { errors, isValid },
   } = useForm<InputForm>({
-    resolver: yupResolver(schema),
+    resolver: yupResolver(activityFormSchema),
     mode: 'onBlur',
   });
 

--- a/src/components/MyActivityPage/MyActivityForm.tsx
+++ b/src/components/MyActivityPage/MyActivityForm.tsx
@@ -206,7 +206,7 @@ export default function MyActivityForm() {
         <div className="flex flex-col">
           <h2 className="h2-my-act">가격</h2>
           <input
-            className="input-my-act"
+            className="input-my-act no-spinner"
             id="price"
             type="number"
             placeholder="*가격"

--- a/src/lib/utils/activityFormSchema.ts
+++ b/src/lib/utils/activityFormSchema.ts
@@ -1,0 +1,18 @@
+import * as yup from 'yup';
+
+export const activityFormSchema = yup.object().shape({
+  title: yup.string().required('제목을 입력해주세요.'),
+  description: yup.string().required('설명을 입력해주세요.'),
+  price: yup
+    .number()
+    .typeError('가격은 숫자여야 합니다.')
+    .positive('가격은 양수여야 합니다.')
+    .integer('가격은 정수여야 합니다.')
+    .required('가격을 입력해주세요.')
+    .transform((value, originalValue) =>
+      typeof originalValue === 'string' && originalValue.trim() === ''
+        ? null
+        : value,
+    ),
+  address: yup.string().required('주소를 입력해주세요.'),
+});

--- a/src/lib/utils/myActivityPage.ts
+++ b/src/lib/utils/myActivityPage.ts
@@ -12,7 +12,9 @@ export const checkDuplication = (schedules: Schedule[], schedule: Schedule) => {
 
     const isSameDate = s.date === schedule.date;
     const doesTimeOverlap =
-      (si <= startIdx && startIdx < ei) || (si < endIdx && endIdx <= ei);
+      (si <= startIdx && startIdx < ei) ||
+      (si < endIdx && endIdx <= ei) ||
+      (startIdx <= si && ei <= endIdx);
 
     return isSameDate && doesTimeOverlap;
   });

--- a/src/lib/utils/myActivityPage.ts
+++ b/src/lib/utils/myActivityPage.ts
@@ -1,5 +1,3 @@
-import * as yup from 'yup';
-
 import { AVAILABLE_TIMES } from '@/constants/myActivityPage';
 import { Schedule } from '@/types/activityTypes';
 
@@ -24,20 +22,3 @@ export const checkDuplication = (schedules: Schedule[], schedule: Schedule) => {
   // 겹치는 일정이 존재하면 중복
   return !!overlaps.length;
 };
-
-export const activityFormSchema = yup.object().shape({
-  title: yup.string().required('제목을 입력해주세요.'),
-  description: yup.string().required('설명을 입력해주세요.'),
-  price: yup
-    .number()
-    .typeError('가격은 숫자여야 합니다.')
-    .positive('가격은 양수여야 합니다.')
-    .integer('가격은 정수여야 합니다.')
-    .required('가격을 입력해주세요.')
-    .transform((value, originalValue) =>
-      typeof originalValue === 'string' && originalValue.trim() === ''
-        ? null
-        : value,
-    ),
-  address: yup.string().required('주소를 입력해주세요.'),
-});

--- a/src/lib/utils/myActivityPage.ts
+++ b/src/lib/utils/myActivityPage.ts
@@ -1,3 +1,5 @@
+import * as yup from 'yup';
+
 import { AVAILABLE_TIMES } from '@/constants/myActivityPage';
 import { Schedule } from '@/types/activityTypes';
 
@@ -22,3 +24,20 @@ export const checkDuplication = (schedules: Schedule[], schedule: Schedule) => {
   // 겹치는 일정이 존재하면 중복
   return !!overlaps.length;
 };
+
+export const activityFormSchema = yup.object().shape({
+  title: yup.string().required('제목을 입력해주세요.'),
+  description: yup.string().required('설명을 입력해주세요.'),
+  price: yup
+    .number()
+    .typeError('가격은 숫자여야 합니다.')
+    .positive('가격은 양수여야 합니다.')
+    .integer('가격은 정수여야 합니다.')
+    .required('가격을 입력해주세요.')
+    .transform((value, originalValue) =>
+      typeof originalValue === 'string' && originalValue.trim() === ''
+        ? null
+        : value,
+    ),
+  address: yup.string().required('주소를 입력해주세요.'),
+});

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -63,6 +63,18 @@
     @apply flex h-11 items-center rounded border border-kv-gray-79 bg-white px-2.5 text-kv-md pc:h-14 pc:px-4 pc:text-kv-lg tablet:h-14 tablet:px-4 tablet:text-kv-lg;
   }
 
+  .no-spinner {
+    @apply appearance-none;
+  }
+  .no-spinner::-webkit-outer-spin-button,
+  .no-spinner::-webkit-inner-spin-button {
+    @apply appearance-none m-0;
+  }
+  .no-spinner {
+    @apply appearance-none;
+    -moz-appearance: textfield;
+  }
+
   .schedule-my-act {
     @apply flex gap-5 mobile:gap-1;
   }


### PR DESCRIPTION
## 연관된 이슈

## 작업 내용
- [x] 시간 선택 더 넓은 범위 설정 못하게 처리
- [x] 가격 입력 업다운 화살표 제거
- [x] 인풋 에러 메시지 수정

## 스크린샷
![image](https://github.com/user-attachments/assets/282c39e4-ff5c-415e-a8e4-2fb1dd7007f9)
![image](https://github.com/user-attachments/assets/217b2b0b-5d37-4cfe-84a5-2d8a4ca75d4c)


## 코멘트 및 논의 사항
- 가격 입력 1의 자리는 경우에 따라 필요할 수도 있을 것 같은데 어떻게 생각하시나요? 가끔 에어비엔비같은걸 보면 34,902원 이런것도 있으니까...?