### PR TITLE
[GN-175] fix: 체험상세 예약 진행 도중 닫기 버튼 버그 수정

### DIFF
--- a/src/hooks/useCardEventHandler.ts
+++ b/src/hooks/useCardEventHandler.ts
@@ -37,7 +37,17 @@ export function useCardEventHandler(
     },
 
     handleCloseClick: () => {
-      setReservationState(INITIAL_RESERVATION_STATE);
+      setReservationState((prev) => ({
+        ...prev,
+        date: '',
+        startTime: '',
+        endTime: '',
+        price: 0,
+        headCount: 1,
+        step: 1,
+        isToggleModal: false,
+        scheduleId: 0,
+      }));
     },
 
     handleNextStepClick: () => {


### PR DESCRIPTION
## 연관된 이슈
[GN-175]

## 작업 내용
- [x] 닫기 버튼의 초기화 로직에서 스케쥴 데이터는 유지하도록 수정

## 스크린샷
문제 현상
![예약 데이터 사라지는 문제](https://github.com/user-attachments/assets/3be56ff3-9cf5-4c3c-9788-1ebe20038e3c)

수정 후 결과
![예약 데이터 사라지는 문제 해결](https://github.com/user-attachments/assets/e15aa388-7c93-4c46-b182-53ce1e193c7b)

## 코멘트 및 논의 사항
간단한 로직 수정입니다.

[GN-175]: https://codeitsprint6team1.atlassian.net/browse/GN-175?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ