### PR TITLE
[GN-177] refactor: 체험 상세 렌더링 소요 시간 감소

### DIFF
--- a/src/components/activity/Review.tsx
+++ b/src/components/activity/Review.tsx
@@ -1,4 +1,5 @@
 import StartIcon from '@/assets/icons/icon_star.svg';
+import formatRating from '@/lib/utils/formattedRating';
 
 interface ReviewProps {
   reviewCount: number;
@@ -15,7 +16,7 @@ export function ReviewRating({ reviewCount, rating }: ReviewProps) {
     <div className="flex items-center gap-1">
       <StartIcon />
       <p className="text-kv-lg mobile:text-kv-md">
-        {rating.toFixed(1)} ({reviewCount.toLocaleString()})
+        {formatRating(rating)} ({reviewCount.toLocaleString()})
       </p>
     </div>
   );

--- a/src/components/common/ActivityCard/MyActivityCard.tsx
+++ b/src/components/common/ActivityCard/MyActivityCard.tsx
@@ -1,8 +1,7 @@
-import React, { useState } from 'react';
-
 import KebabContainer from '@/components/common/Kebab/KebabContainer';
 import KebabDelete from '@/components/common/Kebab/KebabDelete';
 import KebabLink from '@/components/common/Kebab/KebabLink';
+import formatRating from '@/lib/utils/formattedRating';
 import { MyActivity } from '@/types/get/activityTypes';
 
 import MyCardContainer from './MyCardLayout';
@@ -26,7 +25,7 @@ function MyActivityCard({ activity, onDelete }: MyActivityCardProps) {
             className="mr-[6px] h-5 w-5 pb-[2px]"
           />
           <span className="text-kv-lg">
-            {activity.rating.toFixed(1)} ({activity.reviewCount})
+            {formatRating(activity.rating)} ({activity.reviewCount})
           </span>
         </div>
         <h3 className="activity-card-title">{activity.title}</h3>

--- a/src/lib/utils/formattedRating.ts
+++ b/src/lib/utils/formattedRating.ts
@@ -1,0 +1,3 @@
+export default function formatRating(rating: number) {
+  return rating === 0 ? '0' : rating.toFixed(1);
+}

--- a/src/pages/activity/[id].tsx
+++ b/src/pages/activity/[id].tsx
@@ -46,6 +46,7 @@ export default function ActivityPage() {
       cacheTime: 10 * 60 * 1000,
       refetchOnWindowFocus: false,
       refetchOnMount: false,
+      retry: 1,
     },
   );
 


### PR DESCRIPTION
## 연관된 이슈

[GN-177](https://codeitsprint6team1.atlassian.net/browse/GN-177)

## 작업 내용

- [x] 체험 상세 페이지 렌더링 소요 시간 감소
- [x] 평점이 0일 때 0.0으로 표시되는거 0으로 표시되게 수정

## 스크린샷
- 전
![1](https://github.com/user-attachments/assets/012844b2-f1ad-4b2d-a33a-67da97443738)
![2](https://github.com/user-attachments/assets/0a157fc0-5ab5-46de-8de4-08ff68d5dc91)
![activity-rendering-9s](https://github.com/user-attachments/assets/06f2ca58-b057-45ba-9f3a-fd6a3e550e81)

- 후
![4](https://github.com/user-attachments/assets/31b6fde0-4a73-49e5-bb17-02defd089f1b)
![3](https://github.com/user-attachments/assets/d5f0c51a-36ca-4969-b8b8-fa717eff4a91)
![activity-rendering-3s](https://github.com/user-attachments/assets/7fed84e5-24ac-4173-bb89-2a29bd7b0dd4)


## 코멘트 및 논의 사항

유저 데이터와 체험 상세 데이터 Query의 retry 값을 1로 수정해서 렌더링 시간 단축시켰습니다


[GN-177]: https://codeitsprint6team1.atlassian.net/browse/GN-177?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ