### PR TITLE
fix(GN-186): 배포 서버 내 이미지(SVG) 깨짐에 따른 SVGR로 미적용 부분 변경

### DIFF
--- a/src/components/common/ActivityCard/MyActivityCard.tsx
+++ b/src/components/common/ActivityCard/MyActivityCard.tsx
@@ -1,3 +1,4 @@
+import RatingStarIcon from '@/assets/icons/icon_star.svg';
 import KebabContainer from '@/components/common/Kebab/KebabContainer';
 import KebabDelete from '@/components/common/Kebab/KebabDelete';
 import KebabLink from '@/components/common/Kebab/KebabLink';
@@ -19,11 +20,14 @@ function MyActivityCard({ activity, onDelete }: MyActivityCardProps) {
     >
       <div className="h-[78px] pc:h-[104px] tablet:h-[82px]">
         <div className="flex items-center">
-          <img
+          <div className="mr-[6px] flex h-5 w-5 items-center pb-[2px]">
+            <RatingStarIcon />
+          </div>
+          {/* <img
             src="/assets/icons/icon_star.svg"
             alt="Twitter"
             className="mr-[6px] h-5 w-5 pb-[2px]"
-          />
+          /> */}
           <span className="text-kv-lg">
             {formatRating(activity.rating)} ({activity.reviewCount})
           </span>

--- a/src/pages/activity/[id].tsx
+++ b/src/pages/activity/[id].tsx
@@ -11,6 +11,7 @@ import ReviewList from '@/components/activity/ReviewList';
 import EmptyState from '@/components/common/EmptyState';
 import Pagination from '@/components/common/Pagination';
 import ActivityPageSkeleton from '@/components/skeletons/ActivityPageSkeleton';
+import { DEFAULT_PROFILE_IMAGE } from '@/constants/defaultAssets';
 import useFetchData from '@/hooks/useFetchData';
 import { usePagination } from '@/hooks/usePagination';
 import { getActivity, getActivityReview } from '@/lib/apis/getApis';
@@ -126,8 +127,7 @@ export default function ActivityPage() {
                   reviews={reviewData.reviews}
                   nickname={userData?.nickname || '익명 사용자'}
                   profileImageUrl={
-                    userData?.profileImageUrl ||
-                    '/assets/icons/icon_profile.svg'
+                    userData?.profileImageUrl || DEFAULT_PROFILE_IMAGE
                   }
                 />
                 <Pagination


### PR DESCRIPTION
## 연관된 이슈

#91 

## 작업 내용

- [x] 배포 서버 내 내 체험 관리 부분 별점 이미지 수정 (img에서 SVGR로 변경)
- [x] 체험 내역 내 리뷰에서 프로필 이미지가 없는 경우, svg 파일이 아닌 png 파일을 전달하도록 변경

## 코멘트 및 논의 사항
PR 승인 빠르게 부탁드립니다.
