### PR TITLE
[GN-187] fix: 모바일 프로필 레이아웃 수정

### DIFF
--- a/public/assets/icons/icon_dropdown.svg
+++ b/public/assets/icons/icon_dropdown.svg
@@ -1,3 +1,3 @@
-<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M5.25 9L12 15.75L18.75 9" stroke="black" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"/>
 </svg>

--- a/public/assets/icons/icon_minus.svg
+++ b/public/assets/icons/icon_minus.svg
@@ -1,4 +1,4 @@
-<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect x="0.5" y="0.5" width="55" height="55" rx="8.5" fill="white" stroke="#DDDDDD"/>
 <path d="M15 28H41.5" stroke="#79747E" stroke-width="3" stroke-linecap="round"/>
 </svg>

--- a/public/assets/icons/icon_plus.svg
+++ b/public/assets/icons/icon_plus.svg
@@ -1,4 +1,4 @@
-<svg width="48" height="48" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
 <path d="M9.25 24.25H38.75" stroke="#4B4B4B" stroke-width="2" stroke-linecap="round"/>
 <path d="M24.25 9.25L24.25 38.75" stroke="#4B4B4B" stroke-width="2" stroke-linecap="round"/>
 </svg>

--- a/public/assets/icons/icon_plus_blue.svg
+++ b/public/assets/icons/icon_plus_blue.svg
@@ -1,4 +1,4 @@
-<svg width="56" height="56" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 56 56" fill="none" xmlns="http://www.w3.org/2000/svg">
 <rect width="56" height="56" rx="9" fill="#3C54D0"/>
 <path d="M15 28H41.5" stroke="white" stroke-width="3" stroke-linecap="round"/>
 <path d="M28 15L28 41.5" stroke="white" stroke-width="3" stroke-linecap="round"/>

--- a/public/assets/icons/icon_x_red.svg
+++ b/public/assets/icons/icon_x_red.svg
@@ -1,4 +1,4 @@
-<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="100%" height="100%" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg">
 <g clip-path="url(#clip0_245_11821)">
 <circle cx="20" cy="20" r="20" fill="#F93347"/>
 <path d="M12 12L28 28" stroke="white" stroke-width="3" stroke-linecap="round"/>

--- a/src/components/MyActivityPage/ImageCard.tsx
+++ b/src/components/MyActivityPage/ImageCard.tsx
@@ -31,13 +31,7 @@ export default function ImageCard({ image, onClickDelete }: ImageProps) {
         type="button"
         onClick={handleDeleteImage}
       >
-        {/* <Image
-          src="/assets/icons/icon_x_red.svg"
-          alt="이미지 삭제"
-          fill
-          className="rounded-full"
-        /> */}
-        <RedXButtonIcon width={'100%'} height={'100%'} />
+        <RedXButtonIcon />
       </button>
     </div>
   );

--- a/src/components/MyActivityPage/ImageInput.tsx
+++ b/src/components/MyActivityPage/ImageInput.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { ChangeEvent, useRef } from 'react';
 
 import PlusIcon from '@/assets/icons/icon_plus.svg';
@@ -28,8 +27,7 @@ export default function ImageInput({ disabled, onChange }: ImageInputProps) {
       className={`${disabled ? 'cursor-not-allowed bg-kv-gray-300 align-center' : 'btn-gray'} size-my-act-img cursor-pointer flex-col gap-[30px] rounded-2xl border-[1.5px] border-dashed`}
     >
       <div className="relative size-12">
-        {/* <Image src="/assets/icons/icon_plus.svg" alt="이미지 추가" fill /> */}
-        <PlusIcon width={'100%'} height={'100%'} />
+        <PlusIcon />
       </div>
       <span className="text-kv-2xl text-kv-gray-4b">이미지 등록</span>
 

--- a/src/components/MyActivityPage/Schedule.tsx
+++ b/src/components/MyActivityPage/Schedule.tsx
@@ -1,5 +1,3 @@
-import Image from 'next/image';
-
 import MinusIcon from '@/assets/icons/icon_minus.svg';
 import { Schedule as ScheduleType } from '@/types/activityTypes';
 
@@ -33,8 +31,7 @@ export default function Schedule({ schedule, onClickDelete }: DateProps) {
           type="button"
           onClick={onClickDelete}
         >
-          {/* <Image src="/assets/icons/icon_minus.svg" alt="날짜 제거" fill /> */}
-          <MinusIcon width={'100%'} height={'100%'} />
+          <MinusIcon className="edit-icon-size" />
         </button>
       </div>
     </div>

--- a/src/components/MyActivityPage/ScheduleInput.tsx
+++ b/src/components/MyActivityPage/ScheduleInput.tsx
@@ -90,12 +90,7 @@ export default function ScheduleInput({ onClickButton }: ScheduleInputProps) {
           disabled={!date || !startTime.value || !endTime.value}
           onClick={handleClickButton}
         >
-          {/* <Image src="/assets/icons/icon_plus_blue.svg" alt="날짜 추가" fill /> */}
-          <PlusButtonBlueIcon
-            width={'100%'}
-            height={'100%'}
-            viewBox={'0 0 56 56'}
-          />
+          <PlusButtonBlueIcon />
         </button>
       </div>
     </div>

--- a/src/components/ReservationDashboardPage/ReservationDashboardDropdown.tsx
+++ b/src/components/ReservationDashboardPage/ReservationDashboardDropdown.tsx
@@ -1,4 +1,3 @@
-import Image from 'next/image';
 import { MouseEventHandler } from 'react';
 
 import DropDownIcon from '@/assets/icons/icon_dropdown.svg';
@@ -44,12 +43,6 @@ export default function ReservationDashboardDropdown({
       >
         <span>{value || placeholder}</span>
         <div className="relative -mr-1 size-5 rounded md:size-6 pc:size-6">
-          {/* <Image
-            src="/assets/icons/icon_dropdown.svg"
-            alt="드롭다운 버튼"
-            fill
-            className={`${isOpen ? 'rotate-180' : ''}`}
-          /> */}
           <DropDownIcon className={`${isOpen ? 'rotate-180' : ''}`} />
         </div>
       </button>

--- a/src/components/common/Modal/ModalContainer.tsx
+++ b/src/components/common/Modal/ModalContainer.tsx
@@ -1,3 +1,4 @@
+import { onMouseDown } from '@/components/myNotificatons/NotificationModal';
 import useScrollLock from '@/hooks/useScrollLock';
 import { ModalContainerProps } from '@/types/modalTypes';
 
@@ -16,12 +17,12 @@ export default function ModalContainer({
   };
 
   return (
-    <>
+    <div onMouseDown={onMouseDown}>
       <div
         className="fixed inset-0 z-30 bg-kv-black opacity-70"
         onClick={handleBackdropClick}
       />
       {children()}
-    </>
+    </div>
   );
 }

--- a/src/components/layout/Footer.tsx
+++ b/src/components/layout/Footer.tsx
@@ -13,16 +13,16 @@ function Footer() {
           <a className="footer-link-style">FAQ</a>
         </div>
         <div className="flex gap-3">
-          <a href="https://facebook.com">
+          <a href="https://facebook.com" target="_blank">
             <FacebookIcon />
           </a>
-          <a href="https://twitter.com">
+          <a href="https://twitter.com" target="_blank">
             <TwitterIcon />
           </a>
-          <a href="https://instagram.com">
+          <a href="https://instagram.com" target="_blank">
             <InstagramIcon />
           </a>
-          <a href="https://youtube.com">
+          <a href="https://youtube.com" target="_blank">
             <YoutubeIcon />
           </a>
         </div>

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -1,6 +1,5 @@
 import { getCookie } from 'cookies-next';
 import { useAtom } from 'jotai';
-import Image from 'next/image';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
@@ -13,12 +12,13 @@ import useFetchData from '@/hooks/useFetchData';
 import useResponsive from '@/hooks/useResponsive';
 import useScrollLock from '@/hooks/useScrollLock';
 import { getUserData } from '@/lib/apis/userApis';
-import { profileImageAtom } from '@/state/profileImageAtom';
+import { nicknameAtom, profileImageAtom } from '@/state/profileAtom';
 import { User } from '@/types/userTypes';
 
 import { ProfileMenu } from './ProfileMenu';
 
 function Header() {
+  const [nickname, setNickname] = useAtom(nicknameAtom);
   const [profileImage, setProfileImage] = useAtom(profileImageAtom);
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
@@ -43,10 +43,11 @@ function Header() {
   const isLoggedIn = isSuccess;
 
   useEffect(() => {
-    if (user && user.profileImageUrl) {
+    if (user) {
       setProfileImage(user.profileImageUrl);
+      setNickname(user.nickname);
     }
-  }, [user]);
+  }, [user, setProfileImage, setNickname]);
 
   const [isClient, setIsClient] = useState(false);
   useEffect(() => {
@@ -106,7 +107,7 @@ function Header() {
                 onBlur={handleProfileMenuClose}
               >
                 <HeaderUserProfile
-                  nickname={user.nickname}
+                  nickname={nickname}
                   profileImageUrl={profileImage}
                 />
               </button>

--- a/src/components/layout/ProfileMenu.tsx
+++ b/src/components/layout/ProfileMenu.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
 
+import { Modal, useModal } from '@/components/common/Modal';
 import { onMouseDown } from '@/components/myNotificatons/NotificationModal';
 import useResponsive from '@/hooks/useResponsive';
 import { useLogout } from '@/lib/utils/logout';
@@ -11,12 +12,17 @@ interface ProfileMenuProps {
 export function ProfileMenu({ closeProfileMenu }: ProfileMenuProps) {
   const { isMobile } = useResponsive();
   const logout = useLogout();
+  const { openModal, modalProps } = useModal();
 
   const profileLink = isMobile ? '/profile-menu' : '/profile';
 
   const handleLogout = () => {
-    logout();
-    closeProfileMenu();
+    openModal('confirm', '로그아웃 하시겠습니까?', {
+      onConfirm: () => {
+        logout();
+        closeProfileMenu();
+      },
+    });
   };
 
   const handleLinkClick = () => {
@@ -24,39 +30,46 @@ export function ProfileMenu({ closeProfileMenu }: ProfileMenuProps) {
   };
 
   return (
-    <div
-      className="absolute top-[62px] m-auto w-full max-w-[1200px]"
-      onMouseDown={onMouseDown}
-    >
-      <div className="absolute right-0 flex flex-col rounded-lg border border-kv-gray-400 bg-white">
-        <Link href={profileLink} className="gnb-link" onClick={handleLinkClick}>
-          내 정보
-        </Link>
-        <Link
-          href="/my-reservations"
-          className="gnb-link"
-          onClick={handleLinkClick}
-        >
-          예약 내역
-        </Link>
-        <Link
-          href="/my-activities"
-          className="gnb-link"
-          onClick={handleLinkClick}
-        >
-          내 체험 관리
-        </Link>
-        <Link
-          href="/reservation-dashboard"
-          className="gnb-link"
-          onClick={handleLinkClick}
-        >
-          예약 현황
-        </Link>
-        <button className="gnb-link" onClick={handleLogout}>
-          로그아웃
-        </button>
+    <>
+      <div
+        className="absolute top-[62px] m-auto w-full max-w-[1200px]"
+        onMouseDown={onMouseDown}
+      >
+        <div className="absolute right-0 flex flex-col overflow-hidden rounded-lg border border-kv-gray-400 bg-white">
+          <Link
+            href={profileLink}
+            className="gnb-link"
+            onClick={handleLinkClick}
+          >
+            내 정보
+          </Link>
+          <Link
+            href="/my-reservations"
+            className="gnb-link"
+            onClick={handleLinkClick}
+          >
+            예약 내역
+          </Link>
+          <Link
+            href="/my-activities"
+            className="gnb-link"
+            onClick={handleLinkClick}
+          >
+            내 체험 관리
+          </Link>
+          <Link
+            href="/reservation-dashboard"
+            className="gnb-link"
+            onClick={handleLinkClick}
+          >
+            예약 현황
+          </Link>
+          <button className="gnb-link" onClick={handleLogout}>
+            로그아웃
+          </button>
+        </div>
       </div>
-    </div>
+      <Modal {...modalProps} />
+    </>
   );
 }

--- a/src/components/userProfile/EditProfileForm.tsx
+++ b/src/components/userProfile/EditProfileForm.tsx
@@ -1,4 +1,5 @@
 import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { useAtom } from 'jotai';
 import { useEffect } from 'react';
 import { SubmitHandler, useForm } from 'react-hook-form';
 
@@ -10,11 +11,13 @@ import Modal from '@/components/common/Modal/Modal';
 import useFetchData from '@/hooks/useFetchData';
 import { updateUserData } from '@/lib/apis/patchApis';
 import { getUserData } from '@/lib/apis/userApis';
+import { nicknameAtom } from '@/state/profileAtom';
 import { ProfileFormTypes } from '@/types/userTypes';
 
 export default function EditProfileForm() {
   const queryClient = useQueryClient();
   const { modalProps, openModal } = useModal();
+  const [nickname, setNickname] = useAtom(nicknameAtom);
 
   const { data: userData, isError } = useFetchData(
     ['userProfile'],
@@ -61,6 +64,7 @@ export default function EditProfileForm() {
 
     if (formData.nickname !== userData?.nickname) {
       updateData.nickname = formData.nickname;
+      setNickname(formData.nickname);
     }
 
     if (formData.newPassword) {

--- a/src/components/userProfile/EditProfileImage.tsx
+++ b/src/components/userProfile/EditProfileImage.tsx
@@ -11,7 +11,7 @@ import useFetchData from '@/hooks/useFetchData';
 import { updateUserData } from '@/lib/apis/patchApis';
 import { postProfileImage } from '@/lib/apis/postApis';
 import { getUserData } from '@/lib/apis/userApis';
-import { profileImageAtom } from '@/state/profileImageAtom';
+import { profileImageAtom } from '@/state/profileAtom';
 
 export default function EditProfileImage() {
   const queryClient = useQueryClient();

--- a/src/pages/profile-menu.tsx
+++ b/src/pages/profile-menu.tsx
@@ -1,5 +1,9 @@
 import LeftNaviBar from '@/components/common/LeftNavBar';
 
 export default function ProfileMenuPage() {
-  return <LeftNaviBar />;
+  return (
+    <div className="m-5 mb-36">
+      <LeftNaviBar />
+    </div>
+  );
 }

--- a/src/state/profileAtom.ts
+++ b/src/state/profileAtom.ts
@@ -3,3 +3,4 @@ import { atom } from 'jotai';
 import { DEFAULT_PROFILE_IMAGE } from '@/constants/defaultAssets';
 
 export const profileImageAtom = atom<string>(DEFAULT_PROFILE_IMAGE);
+export const nicknameAtom = atom<string>('');


### PR DESCRIPTION
## 연관된 이슈

[GN-187](https://codeitsprint6team1.atlassian.net/browse/GN-187)

## 작업 내용

- [x] 모바일 내 프로필 카드 여백 조정
- [x] svg 짤리는 아이콘 수정
- [x] 프로필 정보 닉네임 헤더와 연동
- [x] 로그아웃 확인 모달 추가

## 스크린샷
![image](https://github.com/user-attachments/assets/a9a8dc99-e341-42d2-b28f-09182752809b)
![image](https://github.com/user-attachments/assets/8e3055a7-0e7e-478a-b77c-26fe4395b72b)
![image](https://github.com/user-attachments/assets/de5cdc7f-76e6-4c08-9029-fe0b9117f03a)

[GN-187]: https://codeitsprint6team1.atlassian.net/browse/GN-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ