### PR TITLE
[GN-189] Fix: 메인 페이지 내 옵션 관련 버그 및 배너 디자인 적용

### DIFF
--- a/src/components/Auth/AuthLayoutHeader.tsx
+++ b/src/components/Auth/AuthLayoutHeader.tsx
@@ -1,4 +1,5 @@
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 import { useMediaQuery } from 'usehooks-ts';
 
 import KVentureLogo from '@/assets/icons/logo_big.svg';
@@ -7,7 +8,10 @@ import { MOBILE_SIZE } from '@/constants/windowSize';
 
 export default function AuthLayoutHeader() {
   const isMobile = useMediaQuery(MOBILE_SIZE);
+
   return (
-    <Link href="/">{isMobile ? <KVentureMobileLogo /> : <KVentureLogo />}</Link>
+    <Link href="/" onClick={() => redirect('/')}>
+      {isMobile ? <KVentureMobileLogo /> : <KVentureLogo />}
+    </Link>
   );
 }

--- a/src/components/Main/ActivityCategory.tsx
+++ b/src/components/Main/ActivityCategory.tsx
@@ -76,6 +76,9 @@ export default function ActivityCategory() {
             }
           }}
         >
+          <div
+            className={`absolute bottom-0 left-0 top-0 z-10 w-2 rounded-[30px] bg-gradient-to-r from-black opacity-[0.1] pc:hidden tablet:hidden ${!isPrev && 'hidden'}`}
+          />
           {Object.keys(categories).map((v) => {
             return (
               <SwiperSlide key={v}>
@@ -85,6 +88,7 @@ export default function ActivityCategory() {
                     setOptions({
                       ...options,
                       category: categories[v] === '전체' ? '' : categories[v],
+                      keyword: '',
                       page: 1,
                     });
                   }}
@@ -94,6 +98,9 @@ export default function ActivityCategory() {
               </SwiperSlide>
             );
           })}
+          <div
+            className={`absolute bottom-0 right-0 top-0 z-10 w-2 rounded-[30px] bg-gradient-to-l from-black opacity-[0.1] pc:hidden tablet:hidden ${!isNext && 'hidden'}`}
+          />
         </Swiper>
         <div
           className={`category-swiper-button-next absolute right-[3px] top-[12px] z-10 hidden h-8 w-8 cursor-pointer items-center justify-center rounded-full border-2 border-solid bg-white font-kv-bold text-kv-primary-blue pc:flex tablet:${isNext ? 'flex' : 'hidden'}`}

--- a/src/components/Main/BestExperienceCard.tsx
+++ b/src/components/Main/BestExperienceCard.tsx
@@ -17,12 +17,13 @@ export default function BestExperienceCard({ data }: { data: MyActivity }) {
         className="relative flex h-[219px] max-h-[454px] w-[335px] max-w-[696px] flex-col items-center px-0 pc:mx-[50px] pc:h-[410px] pc:w-[640px] tablet:h-[454px] tablet:w-[696px]"
       >
         <div className="absolute flex h-[219px] w-[335px] rounded-[24px] border-none pc:h-[410px] pc:w-[640px] tablet:h-[454px] tablet:w-[696px]">
+          <section className="aspect-square h-[100%] w-[100%] rounded-[24px] bg-gradient-to-t from-black"></section>
           <Image
             fill
             objectFit="cover"
             src={imageError ? DEFAULT_ACTIVITY_IMAGE : bannerImageUrl}
             alt={title}
-            className="absolute aspect-square rounded-[24px]"
+            className="absolute z-[-1] aspect-square rounded-[24px]"
           />
         </div>
         <div className="absolute bottom-0 flex w-[100%] flex-col items-start gap-y-2 px-[20px] py-[20px] pc:gap-y-5 tablet:gap-y-5">
@@ -35,9 +36,8 @@ export default function BestExperienceCard({ data }: { data: MyActivity }) {
                 {rating.toFixed(1)} ({reviewCount})
               </h3>
             )}
-            <h3 className="flex text-white kv-text-xl"></h3>
           </span>
-          <h2 className="kv-text-bold w-[185px] max-w-[300px] overflow-hidden text-ellipsis text-nowrap break-all text-white kv-text-xl pc:w-[300px] pc:kv-text-3xl tablet:w-[300px] tablet:kv-text-3xl">
+          <h2 className="kv-text-bold text-overflow w-[190px] max-w-[350px] text-white kv-text-xl pc:w-[350px] pc:kv-text-3xl tablet:w-[350px] tablet:kv-text-3xl">
             {title}
           </h2>
           <span className="flex gap-x-1 text-white kv-text-md pc:kv-text-xl tablet:kv-text-xl">

--- a/src/components/Main/BestExperienceList.tsx
+++ b/src/components/Main/BestExperienceList.tsx
@@ -4,7 +4,7 @@ import 'swiper/css/navigation';
 
 import { useAtom } from 'jotai';
 import { useEffect } from 'react';
-import { EffectFade, Navigation } from 'swiper/modules';
+import { Autoplay, EffectFade, Navigation } from 'swiper/modules';
 import { Swiper, SwiperSlide } from 'swiper/react';
 
 import NoList from '@/assets/icons/icon_no_list.svg';
@@ -44,7 +44,11 @@ export default function BestExperienceList() {
             spaceBetween={50}
             effect={'fade'}
             slidesPerView={1}
-            modules={[EffectFade, Navigation]}
+            autoplay={{
+              delay: 5000,
+              disableOnInteraction: false,
+            }}
+            modules={[Autoplay, EffectFade, Navigation]}
             navigation={{
               nextEl: '.review-swiper-button-next',
               prevEl: '.review-swiper-button-prev',

--- a/src/components/Main/BestExperienceList.tsx
+++ b/src/components/Main/BestExperienceList.tsx
@@ -38,7 +38,7 @@ export default function BestExperienceList() {
   return (
     <>
       {mostReviewedList.length > 0 ? (
-        <ul className="relative flex max-h-[454px] w-[335px] max-w-[696px] justify-center rounded-xl pc:w-[696px] tablet:w-[696px]">
+        <ul className="relative flex max-h-[454px] w-[335px] max-w-[640px] justify-center rounded-[24px] shadow-[8px_18px_15px_0px_#00000024] pc:mx-[28px] pc:w-[640px] tablet:w-[640px]">
           <Swiper
             loop={true}
             spaceBetween={50}

--- a/src/components/Main/ExperienceCard.tsx
+++ b/src/components/Main/ExperienceCard.tsx
@@ -28,7 +28,7 @@ export default function ExperienceCard({ data }: { data: ActivityListItem }) {
           {rating > 0 && <h3 className="font-kv-bold">{rating.toFixed(1)}</h3>}
           {reviewCount > 0 && <h3 className="font-kv-bold">({reviewCount})</h3>}
         </span>
-        <span className="flex w-[170px] overflow-hidden text-ellipsis text-nowrap font-kv-bold kv-text-lg pc:w-[280px] tablet:w-[210px]">
+        <span className="text-overflow-oneline flex max-w-[165px] font-kv-bold kv-text-lg pc:w-[280px] pc:max-w-[280px] tablet:w-[210px] tablet:max-w-[280px]">
           {title}
         </span>
         <span className="flex gap-x-1 kv-text-lg">

--- a/src/components/Main/ExperienceCard.tsx
+++ b/src/components/Main/ExperienceCard.tsx
@@ -14,13 +14,13 @@ export default function ExperienceCard({ data }: { data: ActivityListItem }) {
   return (
     <li key={id} className="flex flex-col">
       <Link href={`/activity/${id}`}>
-        <span className="relative flex h-[168px] w-[168px] items-center rounded-[24px] pc:h-[283px] pc:w-[283px] tablet:h-[221px] tablet:w-[221px]">
+        <span className="relative flex h-[168px] w-[168px] items-center rounded-[24px] shadow-[0px_20px_20px_10px_#00000024] pc:h-[283px] pc:w-[283px] tablet:h-[221px] tablet:w-[221px]">
           <Image
             fill
             objectFit="cover"
             src={imageError ? DEFAULT_ACTIVITY_IMAGE : bannerImageUrl}
             alt={title}
-            className="absolute rounded-lg"
+            className="absolute rounded-[24px]"
           />
         </span>
         <span className="flex items-center gap-x-1 py-[10px]">

--- a/src/components/Main/ExperienceList.tsx
+++ b/src/components/Main/ExperienceList.tsx
@@ -61,7 +61,7 @@ export default function ExperienceList() {
   }, [options]);
 
   useEffect(() => {
-    setOptions({ ...options, size: size });
+    setOptions({ ...options, size: size, page: 1 });
   }, [size, windowsSize]);
 
   return (

--- a/src/components/Main/MainBannerSection.tsx
+++ b/src/components/Main/MainBannerSection.tsx
@@ -41,7 +41,12 @@ export default function MainBannerSection() {
             {...register('search', {
               onChange: (e) => {
                 if (e.target.value === '')
-                  setOptions({ ...options, keyword: '', page: 1 });
+                  setOptions({
+                    ...options,
+                    keyword: '',
+                    category: '',
+                    page: 1,
+                  });
               },
             })}
             type="search"

--- a/src/components/layout/Header.tsx
+++ b/src/components/layout/Header.tsx
@@ -2,6 +2,7 @@ import { getCookie } from 'cookies-next';
 import { useAtom } from 'jotai';
 import Image from 'next/image';
 import Link from 'next/link';
+import { redirect } from 'next/navigation';
 import { useEffect, useState } from 'react';
 
 import NotificationIcon from '@/assets/icons/icon_notification.svg';
@@ -23,6 +24,7 @@ function Header() {
   const [isProfileMenuOpen, setIsProfileMenuOpen] = useState(false);
   const [isNotificationModalOpen, setIsNotificationModalOpen] = useState(false);
   const { isMobile } = useResponsive();
+
   useScrollLock({
     isOpen: isNotificationModalOpen,
     additionalCondition: isMobile,
@@ -86,7 +88,7 @@ function Header() {
   return (
     <header className="h-[70px] border-b border-gray-300 bg-white p-4 align-center">
       <div className="layout-content-container h-[30px] justify-between">
-        <Link href="/">
+        <Link href="/" onClick={() => redirect('/')}>
           <div className="mr-10 flex cursor-pointer items-center">
             <KVentureLogo />
           </div>

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -615,3 +615,24 @@
     @apply border-b border-kv-gray-400 px-10 py-2 text-center text-kv-md font-kv-medium text-kv-gray-700 last:border-none hover:bg-kv-primary-blue-light hover:text-kv-primary-blue active:bg-kv-primary-blue-light active:text-kv-primary-blue;
   }
 }
+
+/* 메인 페이지 */
+.text-overflow {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+}
+
+.text-overflow-oneline {
+  text-overflow: ellipsis;
+  overflow: hidden;
+  word-break: break-word;
+
+  display: -webkit-box;
+  -webkit-line-clamp: 1;
+  -webkit-box-orient: vertical;
+}


### PR DESCRIPTION
## 연관된 이슈

#71 

## 작업 내용

이번 PR에서 작업한 내용을 간략히 설명해주세요.

- [x] 배너 이미지에 그라디언트 적용
- [x] 헤더 및 로그인 페이지 로고 클릭 시, 데이터가 초기화되지 않고 남아 있는 버그 해결
- [x] 페이지 이동에 따른 반응형 이슈 일시 해결
- [x] 각 체험 목록 타이틀 길이에 따른 줄임 기준 적용
- [x] 배너가 5초마다 자동으로 넘겨지도록 설정
- [x] 배너 이미지에 그림자 설정 진행 중 ...

## 스크린샷
![image](https://github.com/user-attachments/assets/bee47bfe-0bc9-4619-b3d0-3591cf7fcc1d)

## 코멘트 및 논의 사항
일단 그림자 적용까지 완료되면 머지를 진행하겠습니다.